### PR TITLE
Require C++11 for cmake project

### DIFF
--- a/projects/cmake/CMakeLists.txt
+++ b/projects/cmake/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.0)
 project(hebi_cpp_examples)
 
+SET (CMAKE_CXX_STANDARD 11)
+SET (CMAKE_CXX_STANDARD_REQUIRED ON)
+
 if("${CMAKE_BUILD_TYPE}" STREQUAL "")
   set(CMAKE_BUILD_TYPE Debug)
 endif()


### PR DESCRIPTION
(this allows it to build using compilers which don't default to cpp11 -- as is, this doesn't work on my Ubuntu 16.04 install)