### PR TITLE
Improved error catching to prevent log file issues

### DIFF
--- a/basic/io_board/02a_feedback_io_board.cpp
+++ b/basic/io_board/02a_feedback_io_board.cpp
@@ -49,9 +49,15 @@ int main() {
   std::vector<double> x_ticks = {0.0, 1.0, 2.0};
 
   // Start logging (you can also specify log file name as second parameter)
-  std::string full_log_path = group -> startLog("./logs/");
-  // NOTE: This will NOT save if there is no 'logs' folder in the 
-  // location you are running this from
+  std::string log_path = group->startLog("./logs");
+
+  if (log_path.empty()) {
+    std::cout << "~~ERROR~~\n"
+              << "Target directory for log file not found!\n"
+              << "HINT: Remember that the path declared in 'group->startLog()' "
+              << "is relative to your current working directory...\n";
+    return 0;
+  }
 
   for (size_t i = 0; i < 50; ++i)
   {

--- a/basic/io_board/02a_feedback_io_board.cpp
+++ b/basic/io_board/02a_feedback_io_board.cpp
@@ -56,7 +56,7 @@ int main() {
               << "Target directory for log file not found!\n"
               << "HINT: Remember that the path declared in 'group->startLog()' "
               << "is relative to your current working directory...\n";
-    return 0;
+    return 1;
   }
 
   for (size_t i = 0; i < 50; ++i)

--- a/basic/io_board/02b_io_feedback_io_board.cpp
+++ b/basic/io_board/02b_io_feedback_io_board.cpp
@@ -49,9 +49,15 @@ int main() {
   std::vector<double> x_ticks = {0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0};
 
   // Start logging (you can also specify log file name as second parameter)
-  std::string full_log_path = group -> startLog("./logs/");
-  // NOTE: This will NOT save if there is no 'logs' folder in the 
-  // location you are running this from
+  std::string log_path = group->startLog("./logs");
+
+  if (log_path.empty()) {
+    std::cout << "~~ERROR~~\n"
+              << "Target directory for log file not found!\n"
+              << "HINT: Remember that the path declared in 'group->startLog()' "
+              << "is relative to your current working directory...\n";
+    return 0;
+  }
 
   for (size_t i = 0; i < 50; ++i)
   {

--- a/basic/io_board/02b_io_feedback_io_board.cpp
+++ b/basic/io_board/02b_io_feedback_io_board.cpp
@@ -56,7 +56,7 @@ int main() {
               << "Target directory for log file not found!\n"
               << "HINT: Remember that the path declared in 'group->startLog()' "
               << "is relative to your current working directory...\n";
-    return 0;
+    return 1;
   }
 
   for (size_t i = 0; i < 50; ++i)

--- a/basic/mobile_io/02b_feedback_mobile_io_w_logging.cpp
+++ b/basic/mobile_io/02b_feedback_mobile_io_w_logging.cpp
@@ -57,9 +57,15 @@ int main() {
             << std::endl;
 
   // Start logging (you can also specify log file name as second parameter)
-  std::string full_log_path = group -> startLog("./logs/");
-  // NOTE: This will NOT save if there is no 'logs' folder in the 
-  // location you are running this from
+  std::string log_path = group->startLog("./logs");
+
+  if (log_path.empty()) {
+    std::cout << "~~ERROR~~\n"
+              << "Target directory for log file not found!\n"
+              << "HINT: Remember that the path declared in 'group->startLog()' "
+              << "is relative to your current working directory...\n";
+    return 0;
+  }
 
   for (size_t i = 0; i < 50; ++i)
   {

--- a/basic/mobile_io/02b_feedback_mobile_io_w_logging.cpp
+++ b/basic/mobile_io/02b_feedback_mobile_io_w_logging.cpp
@@ -64,7 +64,7 @@ int main() {
               << "Target directory for log file not found!\n"
               << "HINT: Remember that the path declared in 'group->startLog()' "
               << "is relative to your current working directory...\n";
-    return 0;
+    return 1;
   }
 
   for (size_t i = 0; i < 50; ++i)

--- a/basic/mobile_io/02e_feedback_pose_w_logging.cpp
+++ b/basic/mobile_io/02e_feedback_pose_w_logging.cpp
@@ -52,10 +52,15 @@ int main() {
             << std::endl;
 
   // Start logging (you can also specify log file name as second parameter)
-  std::string full_log_path = group -> startLog("./logs/");
-  // NOTE: This will NOT save if there is no 'logs' folder in the 
-  // location you are running this from
-  // If you encounter a segmentation fault error, ^ this is the issue!
+  std::string log_path = group->startLog("./logs");
+
+  if (log_path.empty()) {
+    std::cout << "~~ERROR~~\n"
+              << "Target directory for log file not found!\n"
+              << "HINT: Remember that the path declared in 'group->startLog()' "
+              << "is relative to your current working directory...\n";
+    return 0;
+  }
 
   for (size_t i = 0; i < 50; ++i)
   {

--- a/basic/mobile_io/02e_feedback_pose_w_logging.cpp
+++ b/basic/mobile_io/02e_feedback_pose_w_logging.cpp
@@ -59,7 +59,7 @@ int main() {
               << "Target directory for log file not found!\n"
               << "HINT: Remember that the path declared in 'group->startLog()' "
               << "is relative to your current working directory...\n";
-    return 0;
+    return 1;
   }
 
   for (size_t i = 0; i < 50; ++i)

--- a/basic/x_series_actuator/03a_command_position.cpp
+++ b/basic/x_series_actuator/03a_command_position.cpp
@@ -54,7 +54,7 @@ int main() {
               << "Target directory for log file not found!\n"
               << "HINT: Remember that the path declared in 'group->startLog()' "
               << "is relative to your current working directory...\n";
-    return 0;
+    return 1;
   }
 
   // Parameters for sin/cos function

--- a/basic/x_series_actuator/03a_command_position.cpp
+++ b/basic/x_series_actuator/03a_command_position.cpp
@@ -47,7 +47,15 @@ int main() {
   GroupFeedback group_feedback(group->size());
   
   // Start logging in the background
-  group->startLog("logs");
+  std::string log_path = group->startLog("./logs");
+
+  if (log_path.empty()) {
+    std::cout << "~~ERROR~~\n"
+              << "Target directory for log file not found!\n"
+              << "HINT: Remember that the path declared in 'group->startLog()' "
+              << "is relative to your current working directory...\n";
+    return 0;
+  }
 
   // Parameters for sin/cos function
   double freq_hz = 0.5;               // [Hz]

--- a/basic/x_series_actuator/03b_command_velocity.cpp
+++ b/basic/x_series_actuator/03b_command_velocity.cpp
@@ -25,7 +25,7 @@ using namespace hebi;
 int main() {
   // Get group
   Lookup lookup;
-  auto group = lookup.getGroupFromNames({"Test Family"}, {"Test Actutator"});
+  auto group = lookup.getGroupFromNames({"Test Family"}, {"Test Actuator"});
 
   if (!group) {
     std::cout

--- a/basic/x_series_actuator/03b_command_velocity.cpp
+++ b/basic/x_series_actuator/03b_command_velocity.cpp
@@ -25,7 +25,7 @@ using namespace hebi;
 int main() {
   // Get group
   Lookup lookup;
-  auto group = lookup.getGroupFromNames({"Arm Example"}, {"Wrist1"});
+  auto group = lookup.getGroupFromNames({"Test Family"}, {"Test Actuator"});
 
   if (!group) {
     std::cout

--- a/basic/x_series_actuator/03b_command_velocity.cpp
+++ b/basic/x_series_actuator/03b_command_velocity.cpp
@@ -25,7 +25,7 @@ using namespace hebi;
 int main() {
   // Get group
   Lookup lookup;
-  auto group = lookup.getGroupFromNames({"Test Family"}, {"Test Actuator"});
+  auto group = lookup.getGroupFromNames({"Test Family"}, {"Test Actutator"});
 
   if (!group) {
     std::cout
@@ -51,7 +51,7 @@ int main() {
 
   if (log_path.empty()) {
     std::cout << "~~ERROR~~\n"
-              << "Target directory for log_file not found!\n"
+              << "Target directory for log file not found!\n"
               << "HINT: Remember that the path declared in 'group->startLog()' "
               << "is relative to your current working directory...\n";
     return 0;

--- a/basic/x_series_actuator/03b_command_velocity.cpp
+++ b/basic/x_series_actuator/03b_command_velocity.cpp
@@ -25,7 +25,7 @@ using namespace hebi;
 int main() {
   // Get group
   Lookup lookup;
-  auto group = lookup.getGroupFromNames({"Test Family"}, {"Test Actuator" });
+  auto group = lookup.getGroupFromNames({"Arm Example"}, {"Wrist1"});
 
   if (!group) {
     std::cout
@@ -47,7 +47,15 @@ int main() {
   GroupFeedback group_feedback(group->size());
   
   // Start logging in the background
-  group->startLog("logs");
+  std::string log_path = group->startLog("./logs");
+
+  if (log_path.empty()) {
+    std::cout << "~~ERROR~~\n"
+              << "Target directory for log_file not found!\n"
+              << "HINT: Remember that the path declared in 'group->startLog()' "
+              << "is relative to your current working directory...\n";
+    return 0;
+  }
 
   // Parameters for sin/cos function
   double freq_hz = 0.5;               // [Hz]

--- a/basic/x_series_actuator/03b_command_velocity.cpp
+++ b/basic/x_series_actuator/03b_command_velocity.cpp
@@ -54,7 +54,7 @@ int main() {
               << "Target directory for log file not found!\n"
               << "HINT: Remember that the path declared in 'group->startLog()' "
               << "is relative to your current working directory...\n";
-    return 0;
+    return 1;
   }
 
   // Parameters for sin/cos function

--- a/basic/x_series_actuator/03c_command_effort.cpp
+++ b/basic/x_series_actuator/03c_command_effort.cpp
@@ -54,7 +54,7 @@ int main() {
               << "Target directory for log file not found!\n"
               << "HINT: Remember that the path declared in 'group->startLog()' "
               << "is relative to your current working directory...\n";
-    return 0;
+    return 1;
   }
 
   // Parameters for sin/cos function

--- a/basic/x_series_actuator/03c_command_effort.cpp
+++ b/basic/x_series_actuator/03c_command_effort.cpp
@@ -47,7 +47,15 @@ int main() {
   GroupFeedback group_feedback(group->size());
   
   // Start logging in the background
-  group->startLog("logs");
+  std::string log_path = group->startLog("./logs");
+
+  if (log_path.empty()) {
+    std::cout << "~~ERROR~~\n"
+              << "Target directory for log file not found!\n"
+              << "HINT: Remember that the path declared in 'group->startLog()' "
+              << "is relative to your current working directory...\n";
+    return 0;
+  }
 
   // Parameters for sin/cos function
   double freq_hz = 0.5;               // [Hz]

--- a/basic/x_series_actuator/03d_command_pos_vel.cpp
+++ b/basic/x_series_actuator/03d_command_pos_vel.cpp
@@ -39,7 +39,15 @@ int main() {
   GroupFeedback group_feedback(group->size());
   
   // Start logging in the background
-  group->startLog("logs");
+  std::string log_path = group->startLog("./logs");
+
+  if (log_path.empty()) {
+    std::cout << "~~ERROR~~\n"
+              << "Target directory for log file not found!\n"
+              << "HINT: Remember that the path declared in 'group->startLog()' "
+              << "is relative to your current working directory...\n";
+    return 0;
+  }
 
   // Parameters for sin/cos function
   double freq_hz = 0.5;               // [Hz]

--- a/basic/x_series_actuator/03d_command_pos_vel.cpp
+++ b/basic/x_series_actuator/03d_command_pos_vel.cpp
@@ -46,7 +46,7 @@ int main() {
               << "Target directory for log file not found!\n"
               << "HINT: Remember that the path declared in 'group->startLog()' "
               << "is relative to your current working directory...\n";
-    return 0;
+    return 1;
   }
 
   // Parameters for sin/cos function

--- a/basic/x_series_actuator/03e_command_pos_vel_effort.cpp
+++ b/basic/x_series_actuator/03e_command_pos_vel_effort.cpp
@@ -49,7 +49,15 @@ int main() {
   GroupFeedback group_feedback(group->size());
   
   // Start logging in the background
-  group->startLog("logs");
+  std::string log_path = group->startLog("./logs");
+
+  if (log_path.empty()) {
+    std::cout << "~~ERROR~~\n"
+              << "Target directory for log file not found!\n"
+              << "HINT: Remember that the path declared in 'group->startLog()' "
+              << "is relative to your current working directory...\n";
+    return 0;
+  }
 
   // Parameters for sin/cos function
   double freq_hz = 0.5;               // [Hz]

--- a/basic/x_series_actuator/03e_command_pos_vel_effort.cpp
+++ b/basic/x_series_actuator/03e_command_pos_vel_effort.cpp
@@ -56,7 +56,7 @@ int main() {
               << "Target directory for log file not found!\n"
               << "HINT: Remember that the path declared in 'group->startLog()' "
               << "is relative to your current working directory...\n";
-    return 0;
+    return 1;
   }
 
   // Parameters for sin/cos function

--- a/basic/x_series_actuator/03f_command_vel_w_feedback.cpp
+++ b/basic/x_series_actuator/03f_command_vel_w_feedback.cpp
@@ -36,7 +36,15 @@ int main() {
   GroupFeedback group_feedback(group->size());
   
   // Start logging in the background
-  group->startLog("logs");
+  std::string log_path = group->startLog("./logs");
+
+  if (log_path.empty()) {
+    std::cout << "~~ERROR~~\n"
+              << "Target directory for log file not found!\n"
+              << "HINT: Remember that the path declared in 'group->startLog()' "
+              << "is relative to your current working directory...\n";
+    return 0;
+  }
 
   std::cout << "  Move the module to make the output move..." << std::endl;
 

--- a/basic/x_series_actuator/03f_command_vel_w_feedback.cpp
+++ b/basic/x_series_actuator/03f_command_vel_w_feedback.cpp
@@ -43,7 +43,7 @@ int main() {
               << "Target directory for log file not found!\n"
               << "HINT: Remember that the path declared in 'group->startLog()' "
               << "is relative to your current working directory...\n";
-    return 0;
+    return 1;
   }
 
   std::cout << "  Move the module to make the output move..." << std::endl;

--- a/basic/x_series_actuator/04a_gains_position_kp.cpp
+++ b/basic/x_series_actuator/04a_gains_position_kp.cpp
@@ -47,7 +47,15 @@ int main() {
   GroupFeedback feedback(group->size());
  
   // Start logging in the background
-  group->startLog("logs");
+  std::string log_path = group->startLog("./logs");
+
+  if (log_path.empty()) {
+    std::cout << "~~ERROR~~\n"
+              << "Target directory for log file not found!\n"
+              << "HINT: Remember that the path declared in 'group->startLog()' "
+              << "is relative to your current working directory...\n";
+    return 0;
+  }
 
   // Parameters for step function
   double step_period = 1.0;                  // sec

--- a/basic/x_series_actuator/04a_gains_position_kp.cpp
+++ b/basic/x_series_actuator/04a_gains_position_kp.cpp
@@ -54,7 +54,7 @@ int main() {
               << "Target directory for log file not found!\n"
               << "HINT: Remember that the path declared in 'group->startLog()' "
               << "is relative to your current working directory...\n";
-    return 0;
+    return 1;
   }
 
   // Parameters for step function

--- a/basic/x_series_actuator/05_trajectory.cpp
+++ b/basic/x_series_actuator/05_trajectory.cpp
@@ -79,7 +79,7 @@ int main()
               << "Target directory for log file not found!\n"
               << "HINT: Remember that the path declared in 'group->startLog()' "
               << "is relative to your current working directory...\n";
-    return 0;
+    return 1;
   }
 
   // Follow the trajectory

--- a/basic/x_series_actuator/05_trajectory.cpp
+++ b/basic/x_series_actuator/05_trajectory.cpp
@@ -71,8 +71,16 @@ int main()
 
   auto trajectory = hebi::trajectory::Trajectory::createUnconstrainedQp(time, positions);
 
-    // Start logging in the background
-  group->startLog("logs");
+  // Start logging in the background
+  std::string log_path = group->startLog("./logs");
+
+  if (log_path.empty()) {
+    std::cout << "~~ERROR~~\n"
+              << "Target directory for log file not found!\n"
+              << "HINT: Remember that the path declared in 'group->startLog()' "
+              << "is relative to your current working directory...\n";
+    return 0;
+  }
 
   // Follow the trajectory
   hebi::GroupCommand cmd(num_joints);

--- a/basic/x_series_actuator/07a_robot_3_dof_arm.cpp
+++ b/basic/x_series_actuator/07a_robot_3_dof_arm.cpp
@@ -155,7 +155,7 @@ int main() {
               << "Target directory for log file not found!\n"
               << "HINT: Remember that the path declared in 'group->startLog()' "
               << "is relative to your current working directory...\n";
-    return 0;
+    return 1;
   }
 
   // Get a trajectory from the current position to the first corner of the box: 

--- a/basic/x_series_actuator/07a_robot_3_dof_arm.cpp
+++ b/basic/x_series_actuator/07a_robot_3_dof_arm.cpp
@@ -148,7 +148,15 @@ int main() {
 
   // Set up feedback object, and start logging 
   GroupFeedback feedback(group->size());
-  group->startLog("logs");
+  std::string log_path = group->startLog("./logs");
+
+  if (log_path.empty()) {
+    std::cout << "~~ERROR~~\n"
+              << "Target directory for log file not found!\n"
+              << "HINT: Remember that the path declared in 'group->startLog()' "
+              << "is relative to your current working directory...\n";
+    return 0;
+  }
 
   // Get a trajectory from the current position to the first corner of the box: 
   Eigen::MatrixXd waypoints(group->size(), 2);

--- a/basic/x_series_actuator/07b_robot_6_dof_arm.cpp
+++ b/basic/x_series_actuator/07b_robot_6_dof_arm.cpp
@@ -160,7 +160,7 @@ int main() {
               << "Target directory for log file not found!\n"
               << "HINT: Remember that the path declared in 'group->startLog()' "
               << "is relative to your current working directory...\n";
-    return 0;
+    return 1;
   }
 
   // Get a trajectory from the current position to the first corner of the box: 

--- a/basic/x_series_actuator/07b_robot_6_dof_arm.cpp
+++ b/basic/x_series_actuator/07b_robot_6_dof_arm.cpp
@@ -153,7 +153,15 @@ int main() {
 
   // Set up feedback object, and start logging 
   GroupFeedback feedback(group->size());
-  group->startLog("logs");
+  std::string log_path = group->startLog("./logs");
+
+  if (log_path.empty()) {
+    std::cout << "~~ERROR~~\n"
+              << "Target directory for log file not found!\n"
+              << "HINT: Remember that the path declared in 'group->startLog()' "
+              << "is relative to your current working directory...\n";
+    return 0;
+  }
 
   // Get a trajectory from the current position to the first corner of the box: 
   Eigen::MatrixXd waypoints(group->size(), 2);


### PR DESCRIPTION
Adds a check w/ error message for any file that attempts to create and record into a log file with a faulty path. Raises an error that the log file does not have a proper target directory. The new error message is:

> ~~ ERROR ~~
> Target directory for log file not found!
> HINT: Remember that the path declared in 'group->startLog()' is relative to your current working directory...

This is the fix for issue #56.