### PR TITLE
updated README for CMake build

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,25 +36,9 @@ From the root directory of the checkout, run:
 mkdir build
 cd build
 cmake -DLIBHEBI_TARGET_ARCHITECTURE=armhf ../projects/cmake/
+# LIBHEBI_TARGET_ARCHITECTURE is set x86_64 by default
 make
 ```
-
-to compile the examples.
-
-**64-bit Linux; generates a makefile project**
- 
-From the root directory of the checkout, run:
-
-```
-mkdir build
-cd build
-cmake -DARCH=x86_64 ../projects/cmake/
-```
-
-If CMake is configured to create a Makefile project (the default for Linux), you
-can then run
-
-```make```
 
 to compile the examples.
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ first install CMake.  After doing so, you can run cmake to create the project
 files for your desired platform.  You can run `cmake --help` to get platform-specific
 options, but here are a couple basic examples:
 
+**armhf (raspbian)**
+ 
+From the root directory of the checkout, run:
+
+```
+mkdir build
+cd build
+cmake -DLIBHEBI_TARGET_ARCHITECTURE=armhf ../projects/cmake/
+make
+```
+
+to compile the examples.
+
 **64-bit Linux; generates a makefile project**
  
 From the root directory of the checkout, run:


### PR DESCRIPTION
It seems that ARCH is not used in CMakelists.txt, and LIBHEBI_TARGET_ARCHITECTURE is used to specify the architecture type.