### PR TITLE
Gogiputtar/cpp api version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ projects/**/Debug
 projects/**/Release
 projects/**/x64
 projects/**/*.user
+build
+hebi-cpp
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,23 @@ network.
 
 ## Downloading Dependencies
 
-If cloning the repo directly, you will need to download the C++ API from http://docs.hebi.us/downloads_changelogs.html#software to build the examples and place it in a folder called `hebi-cpp`. If you use the CMake project, it will automatically be downloaded, assuming you have a working internet connection.
+The C++ API should reside in a folder called `hebi-cpp` in the root directory of this repository. This must be downloaded prior to building, and there are two ways to do this:
+
+1. Using the CMake project
+   - Follow the instructions under [CMake](###CMake) and the dependencies will be automatically downloaded.
+   - The API's version is specified in `projects/cmake/DownloadHebiCpp.cmake` through:
+    ```
+    set(HEBI_CPP_VERSION "x.x.x")
+    ```
+    along with its corresponding hash map:
+    ```
+    set(HEBI_CPP_LIB_SHA256 "longstringofcharacters")
+    ```
+    - To change this, first edit the version field, and run the `cmake` command in the build directory. This should give you an error containing the expected hash. Swap this in and run the `cmake` command again.
+
+2. Downloading Manually
+   - Prior to building, you can download your preferred version from [the docs](http://docs.hebi.us/downloads_changelogs.html#software).
+   - Extract the `hebi-cpp` folder from the `hebi-cpp-x.x.x` folder into the root directory of this repository.
 
 For examples which use plotting, python is needed. To install it, execute "sudo apt-get install python3-matplotlib python3-numpy python3.6-dev" in terminal. (Plotting is enabled using a header file matplotlib.h which is a modified version of the one found at https://github.com/lava/matplotlib-cpp)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The C++ API should reside in a folder called `hebi-cpp` in the root directory of
     ```
     set(HEBI_CPP_VERSION "x.x.x")
     ```
-    along with its corresponding hash map:
+    along with its corresponding hash:
     ```
     set(HEBI_CPP_LIB_SHA256 "longstringofcharacters")
     ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ network.
 The C++ API should reside in a folder called `hebi-cpp` in the root directory of this repository. This must be downloaded prior to building, and there are two ways to do this:
 
 1. Using the CMake project
-   - Follow the instructions under [CMake](###CMake) and the dependencies will be automatically downloaded.
+   - Follow the instructions under [CMake](#cmake) and the dependencies will be automatically downloaded.
    - The API's version is specified in `projects/cmake/DownloadHebiCpp.cmake` through:
     ```
     set(HEBI_CPP_VERSION "x.x.x")

--- a/projects/cmake/DownloadHebiCpp.cmake
+++ b/projects/cmake/DownloadHebiCpp.cmake
@@ -1,9 +1,9 @@
 # Used to download the C++ API - this should not be used directly.
 cmake_minimum_required(VERSION 3.0)
 
-set(HEBI_CPP_VERSION "3.5.1")
+set(HEBI_CPP_VERSION "3.9.0")
 set(HEBI_CPP_FILE_NAME "hebi-cpp-${HEBI_CPP_VERSION}.tar.gz")
-set(HEBI_CPP_LIB_SHA256 "383c727ed3aa85bd552374079c7183562aa535266b915ca6b96482a58087ab6f")
+set(HEBI_CPP_LIB_SHA256 "9ad5752448117fb4f5e0f0822c0c596205e4eb33a97aa94e47e81d4d9bc77695")
 set(HEBI_CPP_URL "https://files.hebi.us/download/cpp/${HEBI_CPP_FILE_NAME}")
 
 # If the CMakeLists.txt is not found, then redownload the C++ API 


### PR DESCRIPTION
- Updated to latest API version in cmake project. 
- Updated gitignore to include build/ and hebi-cpp/. 
- Clarified documentation on downloading dependencies.